### PR TITLE
Update Discord invite links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ The team will investigate and take action within **3 business days** of receivin
 Depending on the severity of the violation, actions may include warnings, temporary channel restrictions, or revocation of contribution privileges.
 
 **Contact Information:**  
-- [**Discord:** @Admin](https://discord.com/invite/Y7v493UHBQ)
+- [**Discord:** @Admin](https://discord.gg/HzAnBSCN7t)
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Notipy는 오픈소스 프로젝트로, 누구든지 기여할 수 있습니다.
 ## 커뮤니티
 각종 공지사항 및 봇에대한 도움을 받을 수 있는 곳입니다.
 - 공식 홈페이지 : [링크](https://notipy.code0987.com)
-- 디스코드 지원서버: [초대링크](https://discord.com/invite/Y7v493UHBQ)
+- 디스코드 지원서버: [초대링크](https://discord.gg/HzAnBSCN7t)
 - 또는 봇에게 DM 하세요!
 - 공식 GitHub 저장소: [macqueen0987/notipy](https://github.com/macqueen0987/notipy)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ We provide security updates for the following branches and releases:
 
 Please report security issues **privately** via Discord to out admins
 
-https://discord.gg/Y7v493UHBQ
+https://discord.gg/HzAnBSCN7t
 
 
 Include the following information:

--- a/backend/web/pages/policy.html
+++ b/backend/web/pages/policy.html
@@ -223,7 +223,7 @@
     <h2>제6조 (문의처)</h2>
     <p>서비스 관련 문의는 아래 방법 중 하나를 통해 가능하며, 별도의 이메일 수신은 운영하지 않습니다:</p>
     <ul>
-        <li>디스코드 지원 서버 참여: <a href="https://discord.gg/Y7v493UHBQ">https://discord.gg/Y7v493UHBQ</a></li>
+        <li>디스코드 지원 서버 참여: <a href="https://discord.gg/HzAnBSCN7t">https://discord.gg/HzAnBSCN7t</a></li>
         <li>또는 디스코드에서 봇에게 직접 DM</li>
     </ul>
 
@@ -304,7 +304,7 @@
 
     <h2>제16조 (문의 안내)</h2>
     <p>본 방침과 관련된 문의사항은 디스코드 공식 지원 서버를 통해 접수해주시거나 디스코드 상에서 봇에게 DM 보내시기 바랍니다.</p>
-    <p>📍 지원 서버: <a href="https://discord.gg/Y7v493UHBQ">https://discord.gg/Y7v493UHBQ</a></p>
+    <p>📍 지원 서버: <a href="https://discord.gg/HzAnBSCN7t">https://discord.gg/HzAnBSCN7t</a></p>
     <p>문의 시 개인정보는 별도로 저장되지 않으며, 문의 처리 목적 외로 사용되지 않습니다.</p>
 
     <p>최종 업데이트일: 2025년 5월 30일</p>

--- a/backend/web/pages/terms-consent.html
+++ b/backend/web/pages/terms-consent.html
@@ -162,7 +162,7 @@
         <h2>제6조 (문의처)</h2>
         <p>서비스 관련 문의는 아래 방법 중 하나를 통해 가능하며, 별도의 이메일 수신은 운영하지 않습니다:</p>
         <ul>
-            <li>디스코드 지원 서버 참여: <a href="https://discord.gg/Y7v493UHBQ">https://discord.gg/Y7v493UHBQ</a></li>
+            <li>디스코드 지원 서버 참여: <a href="https://discord.gg/HzAnBSCN7t">https://discord.gg/HzAnBSCN7t</a></li>
             <li>또는 디스코드에서 봇에게 직접 DM</li>
         </ul>
 
@@ -243,7 +243,7 @@
 
         <h2>제16조 (문의 안내)</h2>
         <p>본 방침과 관련된 문의사항은 디스코드 공식 지원 서버를 통해 접수해주시거나 디스코드 상에서 봇에게 DM 보내시기 바랍니다.</p>
-        <p>📍 지원 서버: <a href="https://discord.gg/Y7v493UHBQ">https://discord.gg/Y7v493UHBQ</a></p>
+        <p>📍 지원 서버: <a href="https://discord.gg/HzAnBSCN7t">https://discord.gg/HzAnBSCN7t</a></p>
         <p>문의 시 개인정보는 별도로 저장되지 않으며, 문의 처리 목적 외로 사용되지 않습니다.</p>
 
         <p>최종 업데이트일: 2025년 5월 30일</p>

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -204,7 +204,7 @@ Notipy is an open-source project — contributions are welcome!
 You can get announcements and support through the following:
 
 * Official website: [link](https://notipy.code0987.com)
-* Discord support server: [Invite link](https://discord.com/invite/Y7v493UHBQ)
+* Discord support server: [Invite link](https://discord.gg/HzAnBSCN7t)
 * Or send a DM to the bot!
 * GitHub repository: [macqueen0987/notipy](https://github.com/macqueen0987/notipy)
 

--- a/docs/en/terms-policy.md
+++ b/docs/en/terms-policy.md
@@ -18,7 +18,7 @@ Users must not attempt unauthorized access, tamper with systems or use illegal p
 The code, features and documents of this service are released under the Apache License 2.0. Logos of Discord, GitHub and Notion belong to their respective owners; this service is not an official product of those platforms.
 
 ## Article 6 (Contact)
-For inquiries, join the [Discord support server](https://discord.gg/Y7v493UHBQ) or send the bot a DM. No separate email is provided.
+For inquiries, join the [Discord support server](https://discord.gg/HzAnBSCN7t) or send the bot a DM. No separate email is provided.
 
 _Last updated: May 14, 2025_
 
@@ -87,6 +87,6 @@ We do not provide personal data to third parties or outsource its processing.
 Users connect with a self‑created Notion integration token that has access only to databases they designate. **For security, grant only page read access. Do not grant permissions to edit, delete or share pages.** The company is not liable for issues caused by incorrect permission settings.
 
 ## Article 16 (Inquiries)
-For questions about this policy, join the [official support server](https://discord.gg/Y7v493UHBQ) or DM the bot on Discord. Any information provided for inquiries is not stored and is used solely to respond.
+For questions about this policy, join the [official support server](https://discord.gg/HzAnBSCN7t) or DM the bot on Discord. Any information provided for inquiries is not stored and is used solely to respond.
 
 _Last updated: May 30, 2025_

--- a/docs/ko/terms-policy.md
+++ b/docs/ko/terms-policy.md
@@ -34,4 +34,4 @@ Notipy 디스코드 봇은 Notion과 GitHub 등의 플랫폼과 연동하여 알
 ---
 
 자세한 사항은 [홈페이지의 이용약관 페이지](https://notipy.code0987.com/policy)를 참고해주세요.   
-문의: [지원 서버](https://discord.com/invite/Y7v493UHBQ)에서 문의하거나 봇에게 DM 하세요
+문의: [지원 서버](https://discord.gg/HzAnBSCN7t)에서 문의하거나 봇에게 DM 하세요


### PR DESCRIPTION
### 🤖 AI-Generated Pull Request

This PR updates outdated Discord invite links across documentation and HTML files.

- Replaced old invite URL with `https://discord.gg/HzAnBSCN7t` in docs and web pages.

No code files were modified.

------
https://chatgpt.com/codex/tasks/task_e_6842d957e994832f82e7038ca5ed3550